### PR TITLE
Handle missing package scripts

### DIFF
--- a/lib/generators/generateFScripts.js
+++ b/lib/generators/generateFScripts.js
@@ -30,10 +30,20 @@ gen.init = async () => {
         }
         
         gen.packageJson = await readJson(packagePath);
-        Object.keys(gen.packageJson.scripts).forEach(scriptName => {
+        const scripts =
+            gen.packageJson?.scripts && typeof gen.packageJson.scripts === "object"
+                ? gen.packageJson.scripts
+                : {};
+        const scriptNames = Object.keys(scripts);
+
+        if (scriptNames.length === 0) {
+            mdfile += "\nNo npm scripts found in package.json.\n";
+        }
+
+        scriptNames.forEach(scriptName => {
             mdfile += `\n## ${scriptName}\n\n${
-                gen.packageJson.scripts[scriptName]
-            }\n\n\`\`\`bash\n${gen.packageJson.scripts[scriptName]}\n\`\`\`\n\n`;
+                scripts[scriptName]
+            }\n\n\`\`\`bash\n${scripts[scriptName]}\n\`\`\`\n\n`;
         });
         await writeFile(fscriptsPath, mdfile);
         fsrLog.success("fscripts.md generated successfully!");

--- a/lib/utils/console.js
+++ b/lib/utils/console.js
@@ -11,6 +11,9 @@ const fsrLog = {
     warn: (...args) => {
         console.warn(`${chalk.gray(timestamp())} ${chalk.yellow.bold("⚠ [WARN]")}`, ...args);
     },
+    success: (...args) => {
+        console.log(`${chalk.gray(timestamp())} ${chalk.green.bold("[SUCCESS]")}`, ...args);
+    },
     error: (...args) => {
         console.error(`${chalk.gray(timestamp())} ${chalk.red.bold("× [ERROR]")}`, ...args);
     }

--- a/tests/generators/generateFScripts.test.js
+++ b/tests/generators/generateFScripts.test.js
@@ -21,13 +21,16 @@ vi.mock("../../lib/utils/helpers.js", () => ({
 
 describe("generateFScripts", () => {
     let generateFScripts;
+    let readJson;
     let writeFile;
 
     beforeEach(async () => {
+        vi.clearAllMocks();
         vi.resetModules();
         const mod = await import("../../lib/generators/generateFScripts.js");
         generateFScripts = mod.default;
         const helpers = await import("../../lib/utils/helpers.js");
+        readJson = helpers.readJson;
         writeFile = helpers.writeFile;
     });
 
@@ -55,5 +58,16 @@ describe("generateFScripts", () => {
         await generateFScripts();
         const [, content] = writeFile.mock.calls[0];
         expect(content).toContain("# First category of scripts");
+    });
+
+    it("writes a helpful note when package.json has no scripts", async () => {
+        readJson.mockResolvedValueOnce({ name: "my-lib", version: "1.0.0" });
+
+        await generateFScripts();
+
+        const [, content] = writeFile.mock.calls[0];
+        expect(content).toContain("# First category of scripts");
+        expect(content).toContain("No npm scripts found in package.json.");
+        expect(content).not.toContain("## undefined");
     });
 });


### PR DESCRIPTION
﻿Fixes #25.

`generateFScripts` assumed `packageJson.scripts` was always present, so packages without a `scripts` field hit `Object.keys(undefined)` before `fscripts.md` could be generated. This normalizes missing or non-object `scripts` values to an empty object and writes a short note into the generated file instead of crashing.

While checking the real command path I also found that `generateFScripts` already calls `fsrLog.success`, but the logger did not expose that method. I added the missing success logger so a successful generation does not immediately get caught and printed as a TypeError.

Checked locally:
- `npx vitest run tests/generators/generateFScripts.test.js`
- manual package with no `scripts` field writes `fscripts.md` with `No npm scripts found in package.json.`
- `git diff --check`

I also tried the full suite with `npx vitest run` and `npm run test:coverage`. Both currently fail outside this generator path in the existing completion, doctor, git, and plugins tests on this Windows/Vitest setup, so I kept this PR scoped to the generator bug and its direct coverage.