### PR TITLE
Return empty string when readFile misses

### DIFF
--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -71,11 +71,10 @@ utils.readJson = async f => {
 
 utils.readFile = async f => {
     try {
-        let fl = await fs.readFileSync(f, "utf8");
-        return fl;
+        return await fs.readFile(f, "utf8");
     } catch (err) {
         fsrLog.error(err);
-        return {};
+        return "";
     }
 };
 

--- a/tests/utils/helpers.test.js
+++ b/tests/utils/helpers.test.js
@@ -83,6 +83,12 @@ describe("writeFile / readFile round-trip", () => {
         const contents = await readFile(file);
         expect(contents).toBe("line one\nline two");
     });
+
+    it("readFile returns an empty string when the file is missing", async () => {
+        const contents = await readFile(path.join(tmpDir, "missing.txt"));
+        expect(contents).toBe("");
+        expect(contents.split("\n")).toEqual([""]);
+    });
 });
 
 describe("appendToFile", () => {


### PR DESCRIPTION
Fixes #24.

`utils.readFile` returned `{}` after a read error, but the normal return type is a string. That made callers such as the encryption flow fail later with `.split is not a function`, hiding the original missing-file problem.

This changes `readFile` to use the async `fs.readFile` helper and return an empty string on read failure. Existing string callers can keep using string operations safely, and the error is still logged by the helper.

Checked locally:

- `npx vitest run tests/utils/helpers.test.js`
- `npx vitest run tests/generators/generateFScripts.test.js tests/utils/helpers.test.js`
- `git diff --check`

I also ran `npx vitest run`; the new helpers test passed, but the full suite still has existing Windows/PowerShell failures in completion shell detection, doctor mocks, git changelog mocks, and plugin loader fs mocks. I left those outside this patch.